### PR TITLE
add missing repository field

### DIFF
--- a/activity/activity.info
+++ b/activity/activity.info
@@ -5,3 +5,4 @@ bundle_id = org.sugarlabs.HelloWorld
 exec = sugar-activity activity.HelloWorldActivity
 icon = activity-helloworld
 license = GPLv2+
+repository = https://github.com/sugarlabs/hello-world-fork.git


### PR DESCRIPTION
We should have the repository field in our hello world activity example if we expect new contributors to include it in their activities.

A discussion of the repository field was added to sugar-docs/desktop-activity.md
See https://github.com/sugarlabs/sugar-docs/pull/124